### PR TITLE
edit(deps): update to min python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project uses [MkSlides](https://github.com/MartenBE/mkslides/) to convert M
 
 Requirements:
 
-- Python >= 3.10
+- Python >= 3.12
 
 Install (typically on Ubuntu):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["mkslides>=1,<1.1"]
 dynamic = ["version"]
 name = "geotribu-slides"
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">=3.12,<4.0"
 
 [project.urls]
 Homepage = "https://geotribu.fr"


### PR DESCRIPTION
Was testing a local build / serve on python 3.10, which [is not compatible with `mkslides`](https://www.wheelodex.org/projects/mkslides/). Anyway, the CI seems to be using py3.12 as well.

Tested locally using a python 3.13, it seems to work.