### PR TITLE
fix: copy theme after `mkslides build` is made

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build slides
         run: mkslides build slides/ --site-dir build/mkslides/site
 
+      - name: Copy custom theme to site output
+        run: cp -r theme build/mkslides/site/
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ python -m pip install .
 ### Build
 
 ```sh
-mkslides build slides/
+mkslides build slides/ --site-dir site/
+cp -r theme site/
 ```
 
 The generated website is under `site` subfolder.


### PR DESCRIPTION
Dirty hack proposé après quelques prompts GenAI, qui consiste à copier le thème `geotribu` dans le dossier du build.

Effectivement, dans les slides `.html` générées, il y a ceci dans chaque entête : `<link rel="stylesheet" href="theme/slides/geotribu.css" />`, dossier `theme` qui n'est pas présent et n'a pas l'air d'être copié -> le but de cette PR.

Bon, ça change pas le `mkdocs serve` qui est toujours cassé, à voir si un bump de `mkslides` [vers une version plus récente](https://github.com/MartenBE/mkslides/releases) pourrait aider, je sais pas.

Test sur un build local :

| Avant | Après |
| --- | --- |
| <img width="1920" height="910" alt="image" src="https://github.com/user-attachments/assets/ef30b730-fe27-416f-aef3-d1cdb8a8a105" /> | <img width="1920" height="913" alt="image" src="https://github.com/user-attachments/assets/5f8157ca-68ef-479c-b4f6-41fa3e569425" /> |

Pour ta prochaine intervention à Bristol @Guts :wink: 